### PR TITLE
Fix a warning about previous-line

### DIFF
--- a/smart-newline.el
+++ b/smart-newline.el
@@ -51,7 +51,7 @@
   (save-excursion
     (forward-line)
     (indent-according-to-mode)
-    (previous-line)))
+    (forward-line -1)))
 
 ;;;###autoload
 (defun smart-newline ()


### PR DESCRIPTION
The following warning is fixed.

smart-newline.el:53:6:Warning: `previous-line' used from Lisp code
That command is designed for interactive use only
