### PR TITLE
remove unnecessary package file

### DIFF
--- a/smart-newline-pkg.el
+++ b/smart-newline-pkg.el
@@ -1,2 +1,0 @@
-(define-package "smart-newline" "0.0.1"
-  "provide smart newline(C-m) which includes open-line(C-o) and newline-and-inden(C-j) to bind other features on C-o and C-j.")


### PR DESCRIPTION
I don't know completely correct packaging process in elpa. I had created -pkg.el file on a whim.
But, other extensions don't have original -pkg.el file.  So, I understand it that we must not create a -pkg.el file.

I'm removing -pkg.el.
close #4
